### PR TITLE
Add text elements

### DIFF
--- a/src/web/_variables.scss
+++ b/src/web/_variables.scss
@@ -9,4 +9,4 @@ $white: #ffffff;
 $yellow: #ffc700;
 
 $font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-$line-height: 1.4;
+$line-height: 1.25;

--- a/src/web/_variables.scss
+++ b/src/web/_variables.scss
@@ -2,6 +2,7 @@
 // https://www.figma.com/blog/introducing-figma-community/
 $black: #000000;
 $blue: #6b9bf7;
+$gray: #585858;
 $green: #0faa56;
 $purple: #5551ff;
 $red: #f24E1F;

--- a/src/web/components/Checkup.tsx
+++ b/src/web/components/Checkup.tsx
@@ -3,6 +3,7 @@ import { Statuses } from './Statuses'
 import { AppState } from '../../interfaces'
 import { ConfigButton } from './ConfigButton'
 import { ErrorMessage } from './ErrorMessage'
+import { Body } from './Text'
 import './Checkup.scss'
 
 export interface CheckupProps {
@@ -19,10 +20,10 @@ export const Checkup: React.FC<CheckupProps> = ({ onConfigure, state }) => (
       <Statuses jobs={state.main ? Object.values(state.main.jobs) : []} />
     ) : (
       <ErrorMessage title='Bad config'>
-        <p>
+        <Body>
           Bad configuration file detected:{' '}
           {state.main!.errorMessage || 'unknown error'}
-        </p>
+        </Body>
       </ErrorMessage>
     )}
     <div style={{ flexGrow: 1 }} />

--- a/src/web/components/ConfigButton.tsx
+++ b/src/web/components/ConfigButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Body } from './Text'
 import './ConfigButton.scss'
 
 export const ConfigButton: React.FC<
@@ -6,6 +7,6 @@ export const ConfigButton: React.FC<
 > = props => (
   <div className='config row' {...props}>
     <i className='icono-gear' />
-    <span className='caption'>Configure</span>
+    <Body className='caption'>Configure</Body>
   </div>
 )

--- a/src/web/components/ErrorMessage.tsx
+++ b/src/web/components/ErrorMessage.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Heading } from './Text'
 import './ErrorMessage.scss'
 
 export const ErrorMessage: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
@@ -8,7 +9,7 @@ export const ErrorMessage: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
 }) => (
   <div className='ErrorMessage' {...rest}>
     <i className='ErrorMessage-icon icono-exclamationCircle' />
-    {title && <h2 className='ErrorMessage-title'>{title}</h2>}
+    {title && <Heading>{title}</Heading>}
     <div className='ErrorMessage-content'>{children}</div>
   </div>
 )

--- a/src/web/components/Statuses.md
+++ b/src/web/components/Statuses.md
@@ -19,6 +19,7 @@ Some jobs:
   }, {
     name: 'Big flops',
     state: {
+      message: 'There was an error',
       nextRunDate: new Date(Date.now() + 60),
       status: 'not_ok',
     }

--- a/src/web/components/Statuses.md
+++ b/src/web/components/Statuses.md
@@ -26,6 +26,7 @@ Some jobs:
   }, {
     name: 'Watchu doin',
     state: {
+      lastSuccess: 'this succeeded a while ago',
       status: 'who knows dawg',
       nextRunDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
     }

--- a/src/web/components/Statuses.scss
+++ b/src/web/components/Statuses.scss
@@ -25,13 +25,16 @@ ol.jobs {
   }
 }
 
-span.jobs {
-  color: lightgray;
+.job-estimate {
+  color: $gray;
   display: block;
-  padding: 0.5em;
-  width: 200px;
-  text-align: center;
-  margin: auto;
+  float: right;
+  font-style: italic;
+}
+
+.jobs-empty {
+  color: $gray;
+  padding: 1rem;
 }
 
 .StatusIcon-ok {

--- a/src/web/components/Statuses.tsx
+++ b/src/web/components/Statuses.tsx
@@ -48,9 +48,9 @@ export const Statuses = ({ jobs }: { jobs: Job[] }) => {
             children={job.name}
             style={{ display: 'inline-block' }}
           />
-          <Caption
-            children={!!job.state.lastSuccess && job.state.lastSuccess}
-          />
+          {!!job.state.lastSuccess && (
+            <Caption children={job.state.lastSuccess} />
+          )}
           <Caption
             style={{
               float: 'right',

--- a/src/web/components/Statuses.tsx
+++ b/src/web/components/Statuses.tsx
@@ -36,7 +36,9 @@ const getNextRunEstimate = (job: Job) => {
 
 export const Statuses = ({ jobs }: { jobs: Job[] }) => {
   return !jobs.length ? (
-    <span className='jobs' children='Click "Configure" and setup a job' />
+    <div className='jobs jobs-empty'>
+      <Body center children='Click "Configure" and setup a job' />
+    </div>
   ) : (
     <ol
       className='jobs'
@@ -52,13 +54,7 @@ export const Statuses = ({ jobs }: { jobs: Job[] }) => {
             <Caption children={job.state.lastSuccess} />
           )}
           <Caption
-            style={{
-              float: 'right',
-              fontSize: 'small',
-              display: 'block',
-              color: 'gray',
-              fontStyle: 'italic'
-            }}
+            className='job-estimate'
             children={getNextRunEstimate(job)}
           />
           {!!job.state.message && toMessageDom(job.state.message)}

--- a/src/web/components/Statuses.tsx
+++ b/src/web/components/Statuses.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import clsx from 'clsx'
 import { Job } from '../../interfaces'
+import { Body, Caption } from './Text'
 import './Statuses.scss'
 import moment from 'moment'
 
 const toMessageDom = (msg: string) => (
   <>
     <br />
-    <span className='job-error-msg' children={`Error: ${msg}`} />
+    <Caption className='job-error-msg' children={`Error: ${msg}`} />
   </>
 )
 
@@ -30,7 +31,7 @@ const getNextRunEstimate = (job: Job) => {
   if (!job.state.nextRunDate) return '?'
   const now = new Date().getTime()
   const duration = moment.duration(job.state.nextRunDate.getTime() - now, 'ms')
-  return <span children={`next in: ${duration.humanize()}`} />
+  return `next in: ${duration.humanize()}`
 }
 
 export const Statuses = ({ jobs }: { jobs: Job[] }) => {
@@ -42,9 +43,15 @@ export const Statuses = ({ jobs }: { jobs: Job[] }) => {
       children={jobs.map((job, i) => (
         <div className='job' style={{ clear: 'both' }} key={i}>
           <span children={toStatusIcon(job)} />
-          <span className='job-name' children={job.name} />
-          <span children={!!job.state.lastSuccess && job.state.lastSuccess} />
-          <span
+          <Body
+            className='job-name'
+            children={job.name}
+            style={{ display: 'inline-block' }}
+          />
+          <Caption
+            children={!!job.state.lastSuccess && job.state.lastSuccess}
+          />
+          <Caption
             style={{
               float: 'right',
               fontSize: 'small',

--- a/src/web/components/Text.md
+++ b/src/web/components/Text.md
@@ -1,0 +1,36 @@
+User Interface text comes in a few sizes:
+
+```jsx
+import { Body, Caption, Heading, Subheading } from './Text'
+;
+<>
+  <Heading>Heading</Heading>
+  <Subheading>Subheading</Subheading>
+  <Body>Body</Body>
+  <Caption>Caption</Caption>
+</>
+```
+
+Add the `bold` property for a bold version:
+
+```jsx
+import { Body } from './Text'
+;
+<Body bold>Very heavy stuff</Body>
+```
+
+Add the `center` property to center text:
+
+```jsx
+import { Heading } from './Text'
+;
+<Heading center>Lorem ispum dolor</Heading>
+```
+
+Use the `Text` export to style text within other text:
+
+```jsx
+import { Caption, Text } from './Text'
+;
+<Caption>Lorem ipsum <Text bold>dolor sit</Text> amet</Caption>
+```

--- a/src/web/components/Text.scss
+++ b/src/web/components/Text.scss
@@ -1,0 +1,39 @@
+/// Text
+///
+/// Styles for all user-interface text
+.Text {
+  font: inherit;
+
+  &-bold {
+    font-weight: 700;
+  }
+  &-center {
+    text-align: center;
+  }
+
+  &-heading,
+  &-subheading,
+  &-body,
+  &-caption {
+    display: block;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  &-heading {
+    font-size: 150%; // 24px
+    line-height: 1;  // 24px
+  }
+  &-subheading {
+    font-size: 125%;  // 18px
+    line-height: 1.2; // 24px
+  }
+  &-body {
+    font-size: 100%;      // 16px
+    line-height: inherit; // 20px
+  }
+  &-caption {
+    font-size: 81.25%;  // 13px
+    line-height: 1.231; // 16px
+  }
+}

--- a/src/web/components/Text.tsx
+++ b/src/web/components/Text.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import clsx from 'clsx'
+import './Text.scss'
+
+export interface TextProps extends React.HTMLAttributes<HTMLElement> {
+  bold?: boolean
+  center?: boolean
+  element?: keyof React.ReactHTML
+}
+
+export const Text: React.FC<TextProps> = ({
+  bold,
+  center,
+  className,
+  element: Component = 'span',
+  ...rest
+}) => (
+  <Component
+    className={clsx(
+      'Text',
+      {
+        'Text-bold': bold,
+        'Text-center': center
+      },
+      className
+    )}
+    {...rest}
+  />
+)
+
+export const Heading: React.FC<TextProps> = ({
+  className,
+  element: Component = 'h1',
+  ...rest
+}) => <Text className={clsx('Text-heading', className)} {...rest} />
+
+export const Subheading: React.FC<TextProps> = ({
+  className,
+  element: Component = 'h2',
+  ...rest
+}) => <Text className={clsx('Text-subheading', className)} {...rest} />
+
+export const Body: React.FC<TextProps> = ({
+  className,
+  element: Component = 'p',
+  ...rest
+}) => <Text className={clsx('Text-body', className)} {...rest} />
+
+export const Caption: React.FC<TextProps> = ({ className, ...rest }) => (
+  <Text className={clsx('Text-caption', className)} {...rest} />
+)


### PR DESCRIPTION
### Problem

Text styling/componentization is _hog wild_ currently.

### Solution

* Create some base text components:

  <img width="155" alt="image" src="https://user-images.githubusercontent.com/1858316/67546368-23190f80-f6b1-11e9-8b4c-511d90c0c2f6.png">
* Add a `$gray` color that's [WCAG-contrast compliant](https://webaim.org/resources/contrastchecker/?fcolor=585858&bcolor=FFFFFF)
* Refactor current texts to component

### Testing

Styleguide:

<img width="416" alt="image" src="https://user-images.githubusercontent.com/1858316/67546490-61163380-f6b1-11e9-8c72-e49d0aaab9ef.png">

App:

![app-me-up](https://user-images.githubusercontent.com/1858316/67546572-9ae73a00-f6b1-11e9-96e9-82b0f5c51dec.jpg)
